### PR TITLE
🔧 ci: set up GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,141 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  taplo:
+    name: TOML Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
+      - run: taplo format --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  build:
+    name: Build (${{ matrix.features }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - ""  # no default features (minimal)
+          - "tokio"
+          - "embassy"
+          - "lettre"
+          - "default"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.features }}
+      - name: Build
+        run: |
+          if [ "${{ matrix.features }}" = "" ]; then
+            cargo build --no-default-features
+          elif [ "${{ matrix.features }}" = "default" ]; then
+            cargo build
+          else
+            cargo build --no-default-features --features ${{ matrix.features }}
+          fi
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
+  no_std:
+    name: Build (no_std, thumbv7em-none-eabihf)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: thumbv7em-none-eabihf
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: no_std
+      - run: cargo build --target thumbv7em-none-eabihf --no-default-features
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+
+  outdated-direct:
+    name: Outdated Direct Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-outdated
+      - run: cargo outdated --depth 1 --exit-code 1
+
+  outdated-transitive:
+    name: Outdated Transitive Dependencies
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-outdated
+      - run: cargo outdated --exit-code 1
+
+  udeps:
+    name: Unused Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-udeps
+      - run: cargo udeps --all-targets --all-features
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
-default = ["embassy", "tokio", "lettre", "rustls", "log-04"]
+default = ["embassy", "lettre", "log-04", "rustls", "tokio"]
 # for no_std environments
 std = ["alloc", "embassy-net?/std"]
 alloc = ["embassy-net?/alloc"]
@@ -12,8 +12,8 @@ alloc = ["embassy-net?/alloc"]
 log-04 = ["dep:log"]
 
 #optional integrations with other crates
-tokio = ["std", "dep:tokio", "dep:tokio-rustls", "dep:webpki-roots"]
-rustls = ["std", "dep:rustls"]
+tokio = ["dep:tokio", "dep:tokio-rustls", "dep:webpki-roots", "std"]
+rustls = ["dep:rustls", "std"]
 embassy = ["dep:embassy-net"]
 lettre = ["dep:lettre"]
 
@@ -22,29 +22,24 @@ base64 = { version = "0.22.1", default-features = false }
 log = { version = "0.4.22", optional = true, default-features = false }
 
 # lettre message integration
-lettre = { version = "0.11.15", optional = true, default-features = false, features = [
-    "builder",
-    "dkim",
-] }
+lettre = { version = "0.11.15", optional = true, default-features = false, features = ["builder", "dkim"] }
 
 #tokio integration
 tokio = { version = "1.45.0", optional = true, features = ["io-util"] }
 
 #tokio rustls integration
+rustls = { version = "0.23.27", optional = true }
 tokio-rustls = { version = "0.26.2", optional = true } # hickory-client = "0.25.2"
 webpki-roots = { version = "1.0.0", optional = true }
-rustls = { version = "0.23.27", optional = true }
 
 # embassy integration
 # could just integrate with embedded-io?
-embassy-net = { version = "0.7.0", optional = true, features = [
-    "tcp",
-    "proto-ipv4",
-    "proto-ipv6",
-    "medium-ip",
-] }
-
+embassy-net = { version = "0.7.1", optional = true, features = ["medium-ip", "proto-ipv4", "proto-ipv6", "tcp"] }
 
 [dev-dependencies]
 anyhow = "1"
-tokio = { version = "1.45.0", features = ["rt-multi-thread", "macros", "net"] }
+tokio = { version = "1.45.0", features = ["macros", "net", "rt-multi-thread"] }
+
+[lints.clippy]
+# allow for now because signatures might change
+new_without_default = "allow"

--- a/examples/outbound_587.rs
+++ b/examples/outbound_587.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+use simple_smtp::{Smtp, integrations::tokio::TokioIo};
+use tokio::net::TcpStream;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Connect to codingcat.nl on submission port 587
+    let server = "codingcat.nl:587";
+    let tcp_stream = TcpStream::connect(server).await?;
+
+    // Wrap the TcpStream with TokioIo
+    let tcp_stream = TokioIo(tcp_stream);
+
+    // Create an SMTP client
+    let mut smtp = Smtp::new(tcp_stream);
+
+    // Wait for the server to be ready
+    smtp.ready().await?;
+
+    // Send EHLO command
+    let ehlo_response = smtp.ehlo("example.com").await?;
+    // Print the EHLO response extensions
+
+    for line in ehlo_response.lines() {
+        println!("{line}");
+    }
+    // Disconnect
+    smtp.quit().await?;
+    println!("Disconnected from server.");
+
+    Ok(())
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"

--- a/src/integrations/embassy.rs
+++ b/src/integrations/embassy.rs
@@ -1,5 +1,6 @@
-use crate::ReadWrite;
 use embassy_net::tcp::TcpSocket;
+
+use crate::ReadWrite;
 
 impl ReadWrite for TcpSocket<'_> {
     type Error = EmbassyTcpError;

--- a/src/integrations/tokio.rs
+++ b/src/integrations/tokio.rs
@@ -1,7 +1,9 @@
-use crate::ReadWrite;
 use core::ops::{Deref, DerefMut};
 use std::{array, io::IoSlice};
+
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use crate::ReadWrite;
 
 pub struct TokioIo<T: AsyncRead + AsyncWrite + Unpin + Send>(pub T);
 impl<T: AsyncRead + AsyncWrite + Unpin + Send> Deref for TokioIo<T> {
@@ -78,11 +80,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> ReadWrite for TokioIo<T> {
 
 #[cfg(feature = "rustls")]
 mod rustls_support {
-    use super::TokioIo;
-    use crate::{Error, ReadWrite, Smtp};
     use std::sync::Arc;
+
     use tokio::io::{AsyncRead, AsyncWrite};
     use tokio_rustls::{TlsConnector, client::TlsStream};
+
+    use super::TokioIo;
+    use crate::{Error, ReadWrite, Smtp};
     impl<'buffer, T: AsyncRead + AsyncWrite + Unpin + Send> Smtp<'buffer, TokioIo<T>> {
         pub async fn upgrade_to_tls(
             self,

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -1,8 +1,10 @@
-use crate::{Buffer, ReadWrite};
-use core::ops::Range;
-use core::{fmt::Display, ops::Deref};
+use core::{
+    fmt::Display,
+    ops::{Deref, Range},
+};
 
 use super::{Error, MalformedError};
+use crate::{Buffer, ReadWrite};
 
 #[derive(Debug)]
 pub struct ReplyLine<'a> {

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,12 @@
+include = ["**/*.toml", "*.toml"]
+
+[formatting]
+allowed_blank_lines = 1
+column_width = 120
+reorder_arrays = true
+reorder_keys = false
+
+[[rule]]
+include = ["**/Cargo.toml"]
+keys = ["build-dependencies", "dependencies", "dev-dependencies", "workspace.dependencies", "workspace.lints.clippy"]
+formatting = { reorder_keys = true }


### PR DESCRIPTION
Adds a comprehensive CI pipeline with:

- **fmt**: rustfmt check (nightly)
- **taplo**: TOML formatting check
- **clippy**: lint with all features, deny warnings
- **build**: matrix build for minimal, tokio, embassy, lettre, and default feature combos
- **test**: run the test suite
- **no_std**: build for `thumbv7em-none-eabihf` embedded target
- **docs**: cargo doc with warning denial
- **outdated**: check for outdated dependencies
- **udeps**: check for unused dependencies

Also adds:
- `rustfmt.toml` with import grouping rules
- `taplo.toml` with TOML formatting rules
- clippy lints in `Cargo.toml`

Closes #3