### PR TITLE
⭐ tests: add unit tests + fix Extensions::Auth

### DIFF
--- a/examples/outbound_587.rs
+++ b/examples/outbound_587.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use simple_smtp::{Smtp, integrations::tokio::TokioIo};
+use simple_smtp::{Smtp, integrations::tokio::TokioIo, smtp::Extensions};
 use tokio::net::TcpStream;
 
 #[tokio::main]
@@ -24,6 +24,20 @@ async fn main() -> Result<()> {
     for line in ehlo_response.lines() {
         println!("{line}");
     }
+
+    if ehlo_response.supports(Extensions::StartTls) {
+        let reply = smtp.starttls().await?;
+        for line in reply.lines() {
+            println!("{line}");
+        }
+    }
+
+    let mut smtp = smtp.upgrade_to_tls("codingcat.nl").await?;
+    let ehlo_response = smtp.ehlo("codingcat.nl").await?;
+    for line in ehlo_response.lines() {
+        println!("{line}");
+    }
+
     // Disconnect
     smtp.quit().await?;
     println!("Disconnected from server.");


### PR DESCRIPTION
## Summary
- 🐛 Fixed `Extensions::Auth` to store supported mechanisms (was a unit variant, now `Auth(&str)`)
- Added RFC 3207/4954 warnings for non-conformant STARTTLS/AUTH (behind `log-04` feature)
- ⭐ Added 36 unit tests with RFC citations

## Test plan
- [x] All 36 tests pass
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo fmt --check` clean

Closes #4