### PR TITLE
⭐ message: implement RFC 5322 message formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +136,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "chumsky"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +170,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -552,6 +584,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +717,16 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1052,6 +1118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1191,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "chrono",
  "embassy-net",
  "lettre",
  "log",
@@ -1339,6 +1412,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,10 +1466,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [features]
 default = ["embassy", "lettre", "log-04", "rustls", "tokio"]
 # for no_std environments
-std = ["alloc", "embassy-net?/std"]
+std = ["alloc", "chrono/clock", "embassy-net?/std"]
 alloc = ["embassy-net?/alloc"]
 
 log-04 = ["dep:log"]
@@ -19,6 +19,7 @@ lettre = ["dep:lettre"]
 
 [dependencies]
 base64 = { version = "0.22.1", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4.22", optional = true, default-features = false }
 
 # lettre message integration

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,7 @@ impl core::fmt::Display for MalformedError {
     }
 }
 
+/// Errors related to SMTP protocol issues.
 #[derive(Debug)]
 pub enum ProtocolError {
     AuthorizationError,
@@ -60,6 +61,8 @@ pub enum ProtocolError {
     #[cfg(feature = "lettre")]
     NoSender,
     UnsupportedExtension(Extensions<'static>),
+    /// Header value contains invalid characters (e.g., bare \r\n which could allow injection)
+    InvalidHeader(&'static str),
 }
 
 impl core::fmt::Display for ProtocolError {
@@ -71,6 +74,13 @@ impl core::fmt::Display for ProtocolError {
             ProtocolError::NoSender => write!(f, "Missing \"from\" address on lettre envelope"),
             ProtocolError::UnsupportedExtension(ext) => {
                 write!(f, "Extension {ext} not supported")
+            }
+            ProtocolError::InvalidHeader(name) => {
+                write!(
+                    f,
+                    "Header '{}' contains invalid characters (possible injection)",
+                    name
+                )
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ pub use buffer::Buffer;
 pub mod smtp;
 pub use smtp::Smtp;
 
+pub mod message;
+pub use message::{Message, MessageDate};
+
 pub mod integrations {
     #[cfg(feature = "embassy")]
     mod embassy;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,446 @@
+//! RFC 5322 Internet Message Format implementation.
+//!
+//! Uses chrono for date/time handling - it's battle-tested and `no_std` compatible.
+
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+use core::fmt;
+
+use chrono::{DateTime, FixedOffset, TimeZone};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MessageDate - wrapper around chrono's DateTime
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A date-time value for the Date header, per RFC 5322 §3.3.
+///
+/// Wraps chrono's DateTime for proper RFC 2822 formatting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MessageDate(DateTime<FixedOffset>);
+
+impl MessageDate {
+    /// Create a new date from components.
+    ///
+    /// Returns None if the date components are invalid.
+    #[must_use]
+    pub fn new(
+        year: i32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        minute: u32,
+        second: u32,
+        tz_offset_seconds: i32,
+    ) -> Option<Self> {
+        let offset = FixedOffset::east_opt(tz_offset_seconds)?;
+        offset
+            .with_ymd_and_hms(year, month, day, hour, minute, second)
+            .single()
+            .map(MessageDate)
+    }
+
+    /// Create a date in UTC from components.
+    #[must_use]
+    pub fn utc(
+        year: i32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        minute: u32,
+        second: u32,
+    ) -> Option<Self> {
+        Self::new(year, month, day, hour, minute, second, 0)
+    }
+
+    /// Create a date from a Unix timestamp (seconds since 1970-01-01 00:00:00 UTC).
+    #[must_use]
+    pub fn from_timestamp(secs: i64) -> Option<Self> {
+        DateTime::from_timestamp(secs, 0).map(|dt| MessageDate(dt.fixed_offset()))
+    }
+
+    /// Create a date from a Unix timestamp with milliseconds.
+    #[must_use]
+    pub fn from_timestamp_millis(millis: i64) -> Option<Self> {
+        DateTime::from_timestamp_millis(millis).map(|dt| MessageDate(dt.fixed_offset()))
+    }
+
+    /// Change the timezone offset without converting the time.
+    ///
+    /// This keeps the same year/month/day/hour/minute/second but labels them
+    /// with a different timezone.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use simple_smtp::message::MessageDate;
+    ///
+    /// // You have 14:30 from an RTC, and you know you're in UTC+1
+    /// let date = MessageDate::utc(2025, 12, 7, 14, 30, 0)
+    ///     .unwrap()
+    ///     .at_offset(1, 0)
+    ///     .unwrap();
+    ///
+    /// assert!(date.to_string().contains("14:30:00 +0100"));
+    /// ```
+    #[must_use]
+    pub fn at_offset(self, tz_hour: i32, tz_minute: i32) -> Option<Self> {
+        let offset_seconds = tz_hour * 3600 + tz_minute.signum() * tz_minute.abs() * 60;
+        let offset = FixedOffset::east_opt(offset_seconds)?;
+        let naive = self.0.naive_local();
+        offset.from_local_datetime(&naive).single().map(MessageDate)
+    }
+
+    /// Get the current local time as a MessageDate.
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn now() -> Self {
+        MessageDate(chrono::Local::now().fixed_offset())
+    }
+
+    /// Get the current UTC time as a MessageDate.
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn now_utc() -> Self {
+        MessageDate(chrono::Utc::now().fixed_offset())
+    }
+}
+
+impl fmt::Display for MessageDate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Use format() instead of to_rfc2822() to avoid allocation
+        write!(f, "{}", self.0.format("%a, %d %b %Y %H:%M:%S %z"))
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Message builder - works without alloc!
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// An RFC 5322 email message.
+///
+/// Required fields (Date, From, Message-ID) are set in the constructor.
+/// Optional fields use builder methods like `with_to()`, `with_subject()`, etc.
+///
+/// For multiple recipients, format them yourself: `"a@x.com, b@y.com"`
+#[derive(Debug, Clone)]
+pub struct Message<'a> {
+    date: MessageDate,
+    from: &'a str,
+    message_id: &'a str,
+    to: Option<&'a str>,
+    cc: Option<&'a str>,
+    bcc: Option<&'a str>,
+    subject: Option<&'a str>,
+    reply_to: Option<&'a str>,
+    in_reply_to: Option<&'a str>,
+    references: Option<&'a str>,
+    body: Option<&'a str>,
+}
+
+impl<'a> Message<'a> {
+    /// Create a new message with the required RFC 5322 headers.
+    ///
+    /// - `date`: When the message was composed
+    /// - `from`: The author(s), e.g. `"Me <me@example.com>"`
+    /// - `message_id`: Unique identifier without angle brackets, e.g. `"abc123@example.com"`
+    #[must_use]
+    pub const fn new(date: MessageDate, from: &'a str, message_id: &'a str) -> Self {
+        Self {
+            date,
+            from,
+            message_id,
+            to: None,
+            cc: None,
+            bcc: None,
+            subject: None,
+            reply_to: None,
+            in_reply_to: None,
+            references: None,
+            body: None,
+        }
+    }
+
+    // ── Required field getters ────────────────────────────────────────────────
+
+    /// Get the Date header value.
+    #[must_use]
+    pub const fn date(&self) -> &MessageDate {
+        &self.date
+    }
+
+    /// Get the From header value.
+    #[must_use]
+    pub const fn from(&self) -> &'a str {
+        self.from
+    }
+
+    /// Get the Message-ID (without angle brackets).
+    #[must_use]
+    pub const fn message_id(&self) -> &'a str {
+        self.message_id
+    }
+
+    // ── To ────────────────────────────────────────────────────────────────────
+
+    /// Set the To header. For multiple recipients, format them yourself: `"a@x.com, b@y.com"`
+    #[must_use]
+    pub const fn with_to(mut self, to: &'a str) -> Self {
+        self.to = Some(to);
+        self
+    }
+
+    /// Get the To header value, if set.
+    #[must_use]
+    pub const fn to(&self) -> Option<&'a str> {
+        self.to
+    }
+
+    // ── Cc ────────────────────────────────────────────────────────────────────
+
+    /// Set the Cc header.
+    #[must_use]
+    pub const fn with_cc(mut self, cc: &'a str) -> Self {
+        self.cc = Some(cc);
+        self
+    }
+
+    /// Get the Cc header value, if set.
+    #[must_use]
+    pub const fn cc(&self) -> Option<&'a str> {
+        self.cc
+    }
+
+    // ── Bcc ───────────────────────────────────────────────────────────────────
+
+    /// Set the Bcc header.
+    #[must_use]
+    pub const fn with_bcc(mut self, bcc: &'a str) -> Self {
+        self.bcc = Some(bcc);
+        self
+    }
+
+    /// Get the Bcc header value, if set.
+    #[must_use]
+    pub const fn bcc(&self) -> Option<&'a str> {
+        self.bcc
+    }
+
+    // ── Subject ───────────────────────────────────────────────────────────────
+
+    /// Set the Subject header.
+    #[must_use]
+    pub const fn with_subject(mut self, s: &'a str) -> Self {
+        self.subject = Some(s);
+        self
+    }
+
+    /// Get the Subject header value, if set.
+    #[must_use]
+    pub const fn subject(&self) -> Option<&'a str> {
+        self.subject
+    }
+
+    // ── Reply-To ──────────────────────────────────────────────────────────────
+
+    /// Set the Reply-To header.
+    #[must_use]
+    pub const fn with_reply_to(mut self, r: &'a str) -> Self {
+        self.reply_to = Some(r);
+        self
+    }
+
+    /// Get the Reply-To header value, if set.
+    #[must_use]
+    pub const fn reply_to(&self) -> Option<&'a str> {
+        self.reply_to
+    }
+
+    // ── In-Reply-To ───────────────────────────────────────────────────────────
+
+    /// Set the In-Reply-To header.
+    #[must_use]
+    pub const fn with_in_reply_to(mut self, id: &'a str) -> Self {
+        self.in_reply_to = Some(id);
+        self
+    }
+
+    /// Get the In-Reply-To header value, if set.
+    #[must_use]
+    pub const fn in_reply_to(&self) -> Option<&'a str> {
+        self.in_reply_to
+    }
+
+    // ── References ────────────────────────────────────────────────────────────
+
+    /// Set the References header.
+    #[must_use]
+    pub const fn with_references(mut self, r: &'a str) -> Self {
+        self.references = Some(r);
+        self
+    }
+
+    /// Get the References header value, if set.
+    #[must_use]
+    pub const fn references(&self) -> Option<&'a str> {
+        self.references
+    }
+
+    // ── Body ──────────────────────────────────────────────────────────────────
+
+    /// Set the message body.
+    #[must_use]
+    pub const fn with_body(mut self, b: &'a str) -> Self {
+        self.body = Some(b);
+        self
+    }
+
+    /// Get the message body, if set.
+    #[must_use]
+    pub const fn body(&self) -> Option<&'a str> {
+        self.body
+    }
+
+    // ── Formatting ────────────────────────────────────────────────────────────
+
+    /// Generate a unique Message-ID using current time.
+    #[cfg(feature = "std")]
+    #[must_use]
+    pub fn generate_message_id(domain: &str) -> String {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        alloc::format!("{:x}@{}", ts, domain)
+    }
+}
+
+impl fmt::Display for Message<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Required headers
+        writeln!(f, "Date: {}\r", self.date)?;
+        writeln!(f, "From: {}\r", self.from)?;
+        writeln!(f, "Message-ID: <{}>\r", self.message_id)?;
+
+        // Optional headers
+        if let Some(to) = self.to {
+            writeln!(f, "To: {}\r", to)?;
+        }
+        if let Some(cc) = self.cc {
+            writeln!(f, "Cc: {}\r", cc)?;
+        }
+        if let Some(bcc) = self.bcc {
+            writeln!(f, "Bcc: {}\r", bcc)?;
+        }
+        if let Some(reply_to) = self.reply_to {
+            writeln!(f, "Reply-To: {}\r", reply_to)?;
+        }
+        if let Some(s) = self.subject {
+            writeln!(f, "Subject: {}\r", s)?;
+        }
+        if let Some(r) = self.in_reply_to {
+            writeln!(f, "In-Reply-To: {}\r", r)?;
+        }
+        if let Some(r) = self.references {
+            writeln!(f, "References: {}\r", r)?;
+        }
+
+        // Blank line + body
+        write!(f, "\r\n")?;
+        if let Some(b) = self.body {
+            write!(f, "{}", b)?;
+        }
+
+        Ok(())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn date_format_rfc2822() {
+        let d = MessageDate::utc(2025, 12, 7, 12, 30, 0)
+            .unwrap()
+            .at_offset(1, 0)
+            .unwrap();
+        assert!(d.to_string().contains("Dec 2025"));
+        assert!(d.to_string().contains("12:30:00"));
+        assert!(d.to_string().contains("+0100"));
+    }
+
+    #[test]
+    fn date_invalid_returns_none() {
+        assert!(MessageDate::utc(2025, 13, 1, 0, 0, 0).is_none());
+        assert!(MessageDate::utc(2025, 2, 30, 0, 0, 0).is_none());
+    }
+
+    #[test]
+    fn date_at_offset_changes_label_not_time() {
+        let utc = MessageDate::utc(2025, 12, 7, 12, 0, 0).unwrap();
+        let offset = utc.at_offset(5, 0).unwrap();
+        assert!(offset.to_string().contains("12:00:00 +0500"));
+    }
+
+    #[test]
+    fn date_utc_convenience() {
+        let d = MessageDate::utc(2025, 12, 7, 12, 0, 0).unwrap();
+        assert!(d.to_string().contains("+0000"));
+    }
+
+    #[test]
+    fn date_from_timestamp() {
+        let d = MessageDate::from_timestamp(1735689600).unwrap();
+        assert!(d.to_string().contains("Jan 2025"));
+        assert!(d.to_string().contains("+0000"));
+    }
+
+    #[test]
+    fn date_from_timestamp_millis() {
+        let d = MessageDate::from_timestamp_millis(1_735_689_600_123).unwrap();
+        assert!(d.to_string().contains("Jan 2025"));
+    }
+
+    #[test]
+    fn message_getters() {
+        let d = MessageDate::utc(2025, 12, 7, 12, 0, 0).unwrap();
+        let msg = Message::new(d, "from@example.com", "id@example.com")
+            .with_to("to@example.com")
+            .with_subject("Subject line");
+
+        // Required fields are always present
+        assert_eq!(msg.from(), "from@example.com");
+        assert_eq!(msg.message_id(), "id@example.com");
+
+        // Optional fields return Option
+        assert_eq!(msg.to(), Some("to@example.com"));
+        assert_eq!(msg.subject(), Some("Subject line"));
+        assert_eq!(msg.cc(), None);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
+    fn message_to_string() {
+        let d = MessageDate::utc(2025, 12, 7, 14, 30, 0)
+            .unwrap()
+            .at_offset(-5, 0)
+            .unwrap();
+        let msg = Message::new(d, "Sender <sender@example.com>", "abc123@example.com")
+            .with_to("recipient@example.com")
+            .with_subject("Test email")
+            .with_body("Hello, world!");
+
+        let s = msg.to_string();
+        assert!(s.contains("Date:"));
+        assert!(s.contains("From: Sender <sender@example.com>"));
+        assert!(s.contains("To: recipient@example.com"));
+        assert!(s.contains("Subject: Test email"));
+        assert!(s.contains("Message-ID: <abc123@example.com>"));
+        assert!(s.contains("\r\n\r\nHello, world!"));
+    }
+}

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -1295,4 +1295,66 @@ mod tests {
         assert!(ehlo.supports(Extensions::Auth("LOGIN")));
         assert!(!ehlo.supports(Extensions::Auth("CRAM-MD5")));
     }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Dot-stuffing helper tests (find_crlf_dot)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn find_crlf_dot_empty() {
+        assert_eq!(find_crlf_dot(b""), None);
+    }
+
+    #[test]
+    fn find_crlf_dot_too_short() {
+        assert_eq!(find_crlf_dot(b"ab"), None);
+        assert_eq!(find_crlf_dot(b"\r\n"), None);
+    }
+
+    #[test]
+    fn find_crlf_dot_at_start() {
+        // \r\n. at position 0
+        assert_eq!(find_crlf_dot(b"\r\n.hello"), Some(0));
+    }
+
+    #[test]
+    fn find_crlf_dot_in_middle() {
+        assert_eq!(find_crlf_dot(b"hello\r\n.world"), Some(5));
+    }
+
+    #[test]
+    fn find_crlf_dot_multiple_finds_first() {
+        // Should find the first occurrence
+        assert_eq!(find_crlf_dot(b"a\r\n.b\r\n.c"), Some(1));
+    }
+
+    #[test]
+    fn find_crlf_dot_no_dot() {
+        assert_eq!(find_crlf_dot(b"hello\r\nworld"), None);
+    }
+
+    #[test]
+    fn find_crlf_dot_partial_crlf() {
+        // Just \r without \n
+        assert_eq!(find_crlf_dot(b"hello\r.world"), None);
+        // Just \n without \r
+        assert_eq!(find_crlf_dot(b"hello\n.world"), None);
+    }
+
+    #[test]
+    fn find_crlf_dot_at_end() {
+        assert_eq!(find_crlf_dot(b"hello\r\n."), Some(5));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Header validation error display tests
+    // ══════════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn protocol_error_invalid_header_display() {
+        let err = ProtocolError::InvalidHeader("Subject");
+        let msg = format!("{}", err);
+        assert!(msg.contains("Subject"));
+        assert!(msg.contains("invalid"));
+    }
 }


### PR DESCRIPTION
**DRAFT** - Superseded by PR #34. Keeping for reference.

## Summary
- Adds `message` module with RFC 5322 Internet Message Format support
- `Message` struct with builder pattern for constructing emails
- Header folding and proper escaping for RFC 5322 compliance
- `Mailbox` for email addresses with proper display name quoting/escaping (doesn't implement validation yet)

**Note:** Typed time formatting (`MessageDate`, `TimeOffset`) has been split into a separate PR #31 (issue #30).

Closes #10